### PR TITLE
fix: added additional information in README pertaining to PMD

### DIFF
--- a/IndividualProject/bugs.md
+++ b/IndividualProject/bugs.md
@@ -139,3 +139,162 @@ not look clear compared to PMD output, but hopefully this is not too difficult t
     - **Type**: Bug
     - **Description**: When department not found, `HttpStatus` is `FORBIDDEN`.
     - **Fix**: Change `HttpStatus` to `NOT_FOUND`.
+
+Originally, I used the PMD rulesets:
+
+```
+<ruleset>category/java/errorprone.xml</ruleset>
+<ruleset>rulesets/java/maven-pmd-plugin-default.xml</ruleset>
+```
+
+These were defined as satisfactory rulesets according to this EdStem post ([#140](https://edstem.
+org/us/courses/58089/discussion/5269277?comment=12209100)). However, after adding a
+ruleset, `rulesets/java/quickstart.xml`, I received more violations. These were cleaned up
+after the fact. I'm hoping that I will not be marked off points because the TA specified that
+the `errorprone.xml` and `maven-pmd-plugin-default.xml` would be sufficient. Either way, here
+are the violations corresponding to `rulesets/java/quickstart.xml` that have been resolved.
+
+```
+<file name="/Users/zcox/Library/CloudStorage/GoogleDrive-zsc2107@columbia.edu/My Drive/learning/school/columbia/semester_1/COMS4156_SWE/projects_COMS4156/4156-Miniproject-2024-Students-Java/IndividualProject/src/main/java/dev/coms4156/project/individualproject/Course.java">
+<violation beginline="185" endline="185" begincolumn="17" endcolumn="25" rule="MissingOverride" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="Course" method="toString" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#missingoverride" priority="3">
+The method 'toString()' is missing an @Override annotation.
+</violation>
+</file>
+<file name="/Users/zcox/Library/CloudStorage/GoogleDrive-zsc2107@columbia.edu/My Drive/learning/school/columbia/semester_1/COMS4156_SWE/projects_COMS4156/4156-Miniproject-2024-Students-Java/IndividualProject/src/main/java/dev/coms4156/project/individualproject/Department.java">
+<violation beginline="14" endline="14" begincolumn="17" endcolumn="40" rule="LooseCoupling" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="Department" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#loosecoupling" priority="3">
+Avoid using implementation types like 'HashMap'; use the interface instead
+</violation>
+<violation beginline="29" endline="29" begincolumn="7" endcolumn="30" rule="LooseCoupling" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="Department" method="Department" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#loosecoupling" priority="3">
+Avoid using implementation types like 'HashMap'; use the interface instead
+</violation>
+<violation beginline="82" endline="82" begincolumn="10" endcolumn="33" rule="LooseCoupling" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="Department" method="getCourseSelection" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#loosecoupling" priority="3">
+Avoid using implementation types like 'HashMap'; use the interface instead
+</violation>
+<violation beginline="143" endline="143" begincolumn="17" endcolumn="25" rule="MissingOverride" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="Department" method="toString" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#missingoverride" priority="3">
+The method 'toString()' is missing an @Override annotation.
+</violation>
+</file>
+<file name="/Users/zcox/Library/CloudStorage/GoogleDrive-zsc2107@columbia.edu/My Drive/learning/school/columbia/semester_1/COMS4156_SWE/projects_COMS4156/4156-Miniproject-2024-Students-Java/IndividualProject/src/main/java/dev/coms4156/project/individualproject/IndividualProjectApplication.java">
+<violation beginline="34" endline="34" begincolumn="15" endcolumn="18" rule="MissingOverride" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="IndividualProjectApplication" method="run" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#missingoverride" priority="3">
+The method 'run(String[])' is missing an @Override annotation.
+</violation>
+<violation beginline="36" endline="36" begincolumn="11" endcolumn="30" rule="LiteralsFirstInComparisons" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="IndividualProjectApplication" method="run" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#literalsfirstincomparisons" priority="3">
+Position literals first in String comparisons
+</violation>
+<violation beginline="79" endline="79" begincolumn="5" endcolumn="28" rule="LooseCoupling" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="IndividualProjectApplication" method="resetDataFile" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#loosecoupling" priority="3">
+Avoid using implementation types like 'HashMap'; use the interface instead
+</violation>
+<violation beginline="89" endline="89" begincolumn="5" endcolumn="32" rule="LooseCoupling" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="IndividualProjectApplication" method="resetDataFile" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#loosecoupling" priority="3">
+Avoid using implementation types like 'HashMap'; use the interface instead
+</violation>
+</file>
+<file name="/Users/zcox/Library/CloudStorage/GoogleDrive-zsc2107@columbia.edu/My Drive/learning/school/columbia/semester_1/COMS4156_SWE/projects_COMS4156/4156-Miniproject-2024-Students-Java/IndividualProject/src/main/java/dev/coms4156/project/individualproject/MyFileDatabase.java">
+<violation beginline="24" endline="24" begincolumn="11" endcolumn="38" rule="LooseCoupling" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="MyFileDatabase" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#loosecoupling" priority="3">
+Avoid using implementation types like 'HashMap'; use the interface instead
+</violation>
+<violation beginline="57" endline="57" begincolumn="11" endcolumn="38" rule="LooseCoupling" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="MyFileDatabase" method="deSerializeObjectFromFile" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#loosecoupling" priority="3">
+Avoid using implementation types like 'HashMap'; use the interface instead
+</violation>
+<violation beginline="76" endline="76" begincolumn="26" endcolumn="53" rule="LooseCoupling" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="MyFileDatabase" method="setMapping" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#loosecoupling" priority="3">
+Avoid using implementation types like 'HashMap'; use the interface instead
+</violation>
+<violation beginline="98" endline="98" begincolumn="10" endcolumn="37" rule="LooseCoupling" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="MyFileDatabase" method="getDepartmentMapping" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#loosecoupling" priority="3">
+Avoid using implementation types like 'HashMap'; use the interface instead
+</violation>
+</file>
+<file name="/Users/zcox/Library/CloudStorage/GoogleDrive-zsc2107@columbia.edu/My Drive/learning/school/columbia/semester_1/COMS4156_SWE/projects_COMS4156/4156-Miniproject-2024-Students-Java/IndividualProject/src/main/java/dev/coms4156/project/individualproject/RouteController.java">
+<violation beginline="50" endline="50" begincolumn="20" endcolumn="39" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="isCourseFull" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="51" endline="51" begincolumn="20" endcolumn="41" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="isCourseFull" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="87" endline="87" begincolumn="13" endcolumn="40" rule="LooseCoupling" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="RouteController" method="retrieveDeptMapping" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#loosecoupling" priority="3">
+Avoid using implementation types like 'HashMap'; use the interface instead
+</violation>
+<violation beginline="116" endline="116" begincolumn="20" endcolumn="39" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="retrieveCourse" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="117" endline="117" begincolumn="20" endcolumn="41" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="retrieveCourse" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="120" endline="120" begincolumn="9" endcolumn="32" rule="LooseCoupling" ruleset="Best Practices" package="dev.coms4156.project.individualproject" class="RouteController" method="retrieveCourse" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_bestpractices.html#loosecoupling" priority="3">
+Avoid using implementation types like 'HashMap'; use the interface instead
+</violation>
+<violation beginline="155" endline="155" begincolumn="60" endcolumn="79" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="retrieveDepartment" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="180" endline="180" begincolumn="60" endcolumn="79" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="getMajorCtFromDept" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="203" endline="203" begincolumn="59" endcolumn="78" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="identifyDeptChair" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="227" endline="227" begincolumn="20" endcolumn="39" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="findCourseLocation" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="228" endline="228" begincolumn="20" endcolumn="41" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="findCourseLocation" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="261" endline="261" begincolumn="20" endcolumn="39" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="findCourseInstructor" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="262" endline="262" begincolumn="20" endcolumn="41" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="findCourseInstructor" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="295" endline="295" begincolumn="20" endcolumn="39" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="findCourseTime" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="296" endline="296" begincolumn="20" endcolumn="41" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="findCourseTime" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="323" endline="323" begincolumn="56" endcolumn="75" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="addMajorToDept" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="344" endline="344" begincolumn="61" endcolumn="80" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="removeMajorFromDept" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="367" endline="367" begincolumn="20" endcolumn="39" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="dropStudent" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="368" endline="368" begincolumn="20" endcolumn="41" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="dropStudent" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="406" endline="406" begincolumn="20" endcolumn="39" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="setEnrollmentCount" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="407" endline="407" begincolumn="20" endcolumn="41" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="setEnrollmentCount" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="408" endline="408" begincolumn="20" endcolumn="37" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="setEnrollmentCount" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="440" endline="440" begincolumn="20" endcolumn="39" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="changeCourseTime" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="441" endline="441" begincolumn="20" endcolumn="41" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="changeCourseTime" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="442" endline="442" begincolumn="20" endcolumn="36" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="changeCourseTime" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="474" endline="474" begincolumn="20" endcolumn="39" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="changeCourseTeacher" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="475" endline="475" begincolumn="20" endcolumn="41" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="changeCourseTeacher" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="476" endline="476" begincolumn="20" endcolumn="39" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="changeCourseTeacher" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="510" endline="510" begincolumn="20" endcolumn="39" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="changeCourseLocation" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="511" endline="511" begincolumn="20" endcolumn="41" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="changeCourseLocation" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+<violation beginline="512" endline="512" begincolumn="20" endcolumn="40" rule="UnnecessaryAnnotationValueElement" ruleset="Code Style" package="dev.coms4156.project.individualproject" class="RouteController" method="changeCourseLocation" externalInfoUrl="https://docs.pmd-code.org/pmd-doc-7.3.0/pmd_rules_java_codestyle.html#unnecessaryannotationvalueelement" priority="3">
+Avoid the use of value in annotations when its the only element
+</violation>
+</file>
+```

--- a/IndividualProject/pom.xml
+++ b/IndividualProject/pom.xml
@@ -90,6 +90,7 @@
           <rulesets>
             <ruleset>category/java/errorprone.xml</ruleset>
             <ruleset>rulesets/java/maven-pmd-plugin-default.xml</ruleset>
+            <ruleset>rulesets/java/quickstart.xml</ruleset>
           </rulesets>
         </configuration>
         <executions>

--- a/IndividualProject/src/main/java/dev/coms4156/project/individualproject/Course.java
+++ b/IndividualProject/src/main/java/dev/coms4156/project/individualproject/Course.java
@@ -101,6 +101,15 @@ public class Course implements Serializable {
   }
 
   /**
+   * Returns boolean to determine if a course is full or not.
+   *
+   * @return true if full; else false.
+   */
+  public boolean isCourseFull() {
+    return enrolledStudentCount >= enrollmentCapacity;
+  }
+
+  /**
    * Drops a student from the course if a student is enrolled.
    *
    * @return true if the student is successfully dropped, false otherwise.
@@ -173,6 +182,7 @@ public class Course implements Serializable {
    *
    * @return A formatted string containing the course details.
    */
+  @Override
   public String toString() {
     return "\nInstructor: "
         + instructorName
@@ -196,19 +206,6 @@ public class Course implements Serializable {
   }
 
   /**
-   * Sets a new location for a course. Cannot be null or empty string.
-   *
-   * @param newLocation the name of the new location to assign to the course.
-   * @throws IllegalArgumentException if {@code newLocation} is null or an empty string.
-   */
-  public void reassignLocation(String newLocation) {
-    if (newLocation == null || newLocation.trim().isEmpty()) {
-      throw new IllegalArgumentException("Location cannot be null or empty.");
-    }
-    this.courseLocation = newLocation;
-  }
-
-  /**
    * Sets a new time for a course. Must match the expected format below.
    *
    * @param newTime the new time (string).
@@ -227,11 +224,15 @@ public class Course implements Serializable {
   }
 
   /**
-   * Returns boolean to determine if a course is full or not.
+   * Sets a new location for a course. Cannot be null or empty string.
    *
-   * @return true if full; else false.
+   * @param newLocation the name of the new location to assign to the course.
+   * @throws IllegalArgumentException if {@code newLocation} is null or an empty string.
    */
-  public boolean isCourseFull() {
-    return enrolledStudentCount >= enrollmentCapacity;
+  public void reassignLocation(String newLocation) {
+    if (newLocation == null || newLocation.trim().isEmpty()) {
+      throw new IllegalArgumentException("Location cannot be null or empty.");
+    }
+    this.courseLocation = newLocation;
   }
 }

--- a/IndividualProject/src/main/java/dev/coms4156/project/individualproject/Department.java
+++ b/IndividualProject/src/main/java/dev/coms4156/project/individualproject/Department.java
@@ -2,7 +2,6 @@ package dev.coms4156.project.individualproject;
 
 import java.io.Serial;
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -11,7 +10,7 @@ import java.util.Map;
  */
 public class Department implements Serializable {
   @Serial private static final long serialVersionUID = 234567L;
-  private final HashMap<String, Course> courses;
+  private final Map<String, Course> courses;
   private final String departmentChair;
   private final String deptCode;
   private int numberOfMajors;
@@ -20,15 +19,12 @@ public class Department implements Serializable {
    * Constructs a new Department object with the given parameters.
    *
    * @param deptCode The code of the department.
-   * @param courses A HashMap containing courses offered by the department.
+   * @param courses A Map containing courses offered by the department.
    * @param departmentChair The name of the department chair.
    * @param numberOfMajors The number of majors in the department.
    */
   public Department(
-      String deptCode,
-      HashMap<String, Course> courses,
-      String departmentChair,
-      int numberOfMajors) {
+      String deptCode, Map<String, Course> courses, String departmentChair, int numberOfMajors) {
 
     // check department code for null/empty-string
     if (deptCode == null || deptCode.trim().isEmpty()) {
@@ -51,6 +47,11 @@ public class Department implements Serializable {
     this.numberOfMajors = numberOfMajors;
   }
 
+  /** Gets the department code. */
+  public String getDepartmentCode() {
+    return this.deptCode;
+  }
+
   /**
    * Gets the number of majors in the department.
    *
@@ -69,17 +70,12 @@ public class Department implements Serializable {
     return this.departmentChair;
   }
 
-  /** Gets the department code. */
-  public String getDepartmentCode() {
-    return this.deptCode;
-  }
-
   /**
    * Gets the courses offered by the department.
    *
-   * @return A HashMap containing courses offered by the department.
+   * @return A Map containing courses offered by the department.
    */
-  public HashMap<String, Course> getCourseSelection() {
+  public Map<String, Course> getCourseSelection() {
     return this.courses;
   }
 
@@ -96,24 +92,6 @@ public class Department implements Serializable {
               + "department.");
     }
     this.numberOfMajors--;
-  }
-
-  /**
-   * Adds a new course to the department's course selection.
-   *
-   * @param courseId The ID of the course to add.
-   * @param course The Course object to add.
-   */
-  public void addCourse(String courseId, Course course) {
-    // ensure courseId is not null/empty-string
-    if (courseId == null || courseId.trim().isEmpty()) {
-      throw new IllegalArgumentException("courseId cannot be null or empty.");
-    }
-    // ensure course is not null
-    if (course == null) {
-      throw new IllegalArgumentException("Course cannot be null.");
-    }
-    courses.put(courseId, course);
   }
 
   /**
@@ -136,10 +114,29 @@ public class Department implements Serializable {
   }
 
   /**
+   * Adds a new course to the department's course selection.
+   *
+   * @param courseId The ID of the course to add.
+   * @param course The Course object to add.
+   */
+  public void addCourse(String courseId, Course course) {
+    // ensure courseId is not null/empty-string
+    if (courseId == null || courseId.trim().isEmpty()) {
+      throw new IllegalArgumentException("courseId cannot be null or empty.");
+    }
+    // ensure course is not null
+    if (course == null) {
+      throw new IllegalArgumentException("Course cannot be null.");
+    }
+    courses.put(courseId, course);
+  }
+
+  /**
    * Returns a string representation of the department, including its code and the courses offered.
    *
    * @return A string representing the department.
    */
+  @Override
   public String toString() {
     StringBuilder result = new StringBuilder();
     if (!courses.isEmpty()) {

--- a/IndividualProject/src/main/java/dev/coms4156/project/individualproject/IndividualProjectApplication.java
+++ b/IndividualProject/src/main/java/dev/coms4156/project/individualproject/IndividualProjectApplication.java
@@ -2,6 +2,7 @@ package dev.coms4156.project.individualproject;
 
 import jakarta.annotation.PreDestroy;
 import java.util.HashMap;
+import java.util.Map;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -15,6 +16,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 @SpringBootApplication
 public class IndividualProjectApplication implements CommandLineRunner {
 
+  private static final String SETUP_COMMAND = "setup";
+  public static MyFileDatabase myFileDatabase;
+  private static boolean saveData = true;
+
   /**
    * The main launcher for the service all it does is make a call to the overridden run method.
    *
@@ -25,15 +30,26 @@ public class IndividualProjectApplication implements CommandLineRunner {
   }
 
   /**
+   * Overrides the database reference, used when testing.
+   *
+   * @param testData A {@code MyFileDatabase} object referencing test data.
+   */
+  public static void overrideDatabase(MyFileDatabase testData) {
+    myFileDatabase = testData;
+    saveData = false;
+  }
+
+  /**
    * This contains all the setup logic, it will mainly be focused on loading up and creating an
    * instance of the database based off a saved file or will create a fresh database if the file is
    * not present.
    *
    * @param args A {@code String[]} of any potential runtime args
    */
+  @Override
   public void run(String[] args) {
     for (String arg : args) {
-      if (arg.equals("setup")) {
+      if (SETUP_COMMAND.equals(arg)) {
         myFileDatabase = new MyFileDatabase(1, "./data.txt");
         resetDataFile();
         System.out.println("System Setup");
@@ -42,16 +58,6 @@ public class IndividualProjectApplication implements CommandLineRunner {
     }
     myFileDatabase = new MyFileDatabase(0, "./data.txt");
     System.out.println("Start up");
-  }
-
-  /**
-   * Overrides the database reference, used when testing.
-   *
-   * @param testData A {@code MyFileDatabase} object referencing test data.
-   */
-  public static void overrideDatabase(MyFileDatabase testData) {
-    myFileDatabase = testData;
-    saveData = false;
   }
 
   /** Allows for data to be reset in event of errors. */
@@ -76,7 +82,7 @@ public class IndividualProjectApplication implements CommandLineRunner {
     coms3827.setEnrolledStudentCount(283);
     Course coms4156 = new Course("Gail Kaiser", "501 NWC", times[2], 120);
     coms4156.setEnrolledStudentCount(109);
-    HashMap<String, Course> courses = new HashMap<>();
+    Map<String, Course> courses = new HashMap<>();
     courses.put("1004", coms1004);
     courses.put("3134", coms3134);
     courses.put("3157", coms3157);
@@ -86,7 +92,7 @@ public class IndividualProjectApplication implements CommandLineRunner {
     courses.put("3827", coms3827);
     courses.put("4156", coms4156);
     Department compSci = new Department("COMS", courses, "Luca Carloni", 2700);
-    HashMap<String, Department> mapping = new HashMap<>();
+    Map<String, Department> mapping = new HashMap<>();
     mapping.put("COMS", compSci);
 
     // data for econ dept
@@ -289,8 +295,4 @@ public class IndividualProjectApplication implements CommandLineRunner {
       myFileDatabase.saveContentsToFile();
     }
   }
-
-  // Database Instance
-  public static MyFileDatabase myFileDatabase;
-  private static boolean saveData = true;
 }

--- a/IndividualProject/src/main/java/dev/coms4156/project/individualproject/MyFileDatabase.java
+++ b/IndividualProject/src/main/java/dev/coms4156/project/individualproject/MyFileDatabase.java
@@ -21,7 +21,7 @@ public class MyFileDatabase {
   private final String filePath;
 
   /** The mapping of department names to Department objects. */
-  private HashMap<String, Department> departmentMapping;
+  private Map<String, Department> departmentMapping;
 
   /**
    * Constructs a MyFileDatabase object and loads up the data structure with the contents of the
@@ -49,25 +49,16 @@ public class MyFileDatabase {
   }
 
   /**
-   * Sets the department mapping of the database.
-   *
-   * @param mapping the mapping of department names to Department objects
-   */
-  public void setMapping(HashMap<String, Department> mapping) {
-    this.departmentMapping = mapping;
-  }
-
-  /**
    * Deserializes the object from the file and returns the department mapping.
    *
    * @return the deserialized department mapping
    */
   @SuppressWarnings("unchecked")
-  private HashMap<String, Department> deSerializeObjectFromFile() {
+  private Map<String, Department> deSerializeObjectFromFile() {
     try (ObjectInputStream in = new ObjectInputStream(new FileInputStream(filePath))) {
       Object obj = in.readObject();
       if (obj instanceof HashMap) {
-        return (HashMap<String, Department>) obj;
+        return (Map<String, Department>) obj;
       } else {
         throw new IllegalArgumentException("Invalid object type in file.");
       }
@@ -75,6 +66,15 @@ public class MyFileDatabase {
       e.printStackTrace();
       return new HashMap<>();
     }
+  }
+
+  /**
+   * Sets the department mapping of the database.
+   *
+   * @param mapping the mapping of department names to Department objects
+   */
+  public void setMapping(Map<String, Department> mapping) {
+    this.departmentMapping = mapping;
   }
 
   /**
@@ -95,7 +95,7 @@ public class MyFileDatabase {
    *
    * @return the department mapping
    */
-  public HashMap<String, Department> getDepartmentMapping() {
+  public Map<String, Department> getDepartmentMapping() {
     return this.departmentMapping;
   }
 

--- a/IndividualProject/src/main/java/dev/coms4156/project/individualproject/RouteController.java
+++ b/IndividualProject/src/main/java/dev/coms4156/project/individualproject/RouteController.java
@@ -1,7 +1,7 @@
 package dev.coms4156.project.individualproject;
 
-import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -21,36 +21,6 @@ public class RouteController {
       "Attribute was updated successfully.";
 
   /**
-   * Helper function to determine if a department exists.
-   *
-   * @param deptCode A {@code String} representing the department the user wishes to retrieve.
-   * @return A {@code boolean} determining if department exists or not.
-   */
-  protected boolean doesDepartmentExist(String deptCode) {
-    return retrieveDepartment(deptCode).getStatusCode() == HttpStatus.OK;
-  }
-
-  /**
-   * Helper function to determine if a course exists.
-   *
-   * @param deptCode A {@code String} representing the department the user wishes to retrieve.
-   * @param courseCode A {@code int} representing the course the user wishes to retrieve.
-   * @return A {@code boolean} determining if a course exists or not.
-   */
-  protected boolean doesCourseExist(String deptCode, int courseCode) {
-    return retrieveCourse(deptCode, courseCode).getStatusCode() == HttpStatus.OK;
-  }
-
-  /**
-   * Helper function to retrieve a department's mapping.
-   *
-   * @return A hashmap containing all departments and their designated properties.
-   */
-  protected HashMap<String, Department> retrieveDeptMapping() {
-    return IndividualProjectApplication.myFileDatabase.getDepartmentMapping();
-  }
-
-  /**
    * Redirects to the homepage.
    *
    * @return A String containing the name of the html file to be loaded.
@@ -67,62 +37,6 @@ public class RouteController {
   }
 
   /**
-   * Returns the details of the specified department.
-   *
-   * @param deptCode A {@code String} representing the department the user wishes to retrieve.
-   * @return A {@code ResponseEntity} object containing either the details of the Department and an
-   *     HTTP 200 response or, an appropriate message indicating the proper response.
-   */
-  @GetMapping(value = "/retrieveDept", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<?> retrieveDepartment(@RequestParam(value = DEPT_CODE) String deptCode) {
-    try {
-      if (!retrieveDeptMapping().containsKey(deptCode.toUpperCase(Locale.ENGLISH))) {
-        return new ResponseEntity<>(DEPARTMENT_NOT_FOUND, HttpStatus.NOT_FOUND);
-      } else {
-        return new ResponseEntity<>(
-            retrieveDeptMapping().get(deptCode.toUpperCase(Locale.ENGLISH)).toString(),
-            HttpStatus.OK);
-      }
-
-    } catch (Exception e) {
-      return handleException(e);
-    }
-  }
-
-  /**
-   * Displays the details of the requested course to the user or displays the proper error message
-   * in response to the request.
-   *
-   * @param deptCode A {@code String} representing the department the user wishes to find the course
-   *     in.
-   * @param courseCode A {@code int} representing the course the user wishes to retrieve.
-   * @return A {@code ResponseEntity} object containing either the details of the course and an HTTP
-   *     200 response or, an appropriate message indicating the proper response.
-   */
-  @GetMapping(value = "/retrieveCourse", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<?> retrieveCourse(
-      @RequestParam(value = DEPT_CODE) String deptCode,
-      @RequestParam(value = COURSE_CODE) int courseCode) {
-    try {
-      if (doesDepartmentExist(deptCode)) {
-        HashMap<String, Course> coursesMapping =
-            retrieveDeptMapping().get(deptCode).getCourseSelection();
-
-        if (!coursesMapping.containsKey(Integer.toString(courseCode))) {
-          return new ResponseEntity<>(COURSE_NOT_FOUND, HttpStatus.NOT_FOUND);
-        } else {
-          return new ResponseEntity<>(
-              coursesMapping.get(Integer.toString(courseCode)).toString(), HttpStatus.OK);
-        }
-      } else {
-        return new ResponseEntity<>(DEPARTMENT_NOT_FOUND, HttpStatus.NOT_FOUND);
-      }
-    } catch (Exception e) {
-      return handleException(e);
-    }
-  }
-
-  /**
    * Displays whether the course has at minimum reached its enrollmentCapacity.
    *
    * @param deptCode A {@code String} representing the department the user wishes to find the course
@@ -133,8 +47,7 @@ public class RouteController {
    */
   @GetMapping(value = "/isCourseFull", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<?> isCourseFull(
-      @RequestParam(value = DEPT_CODE) String deptCode,
-      @RequestParam(value = COURSE_CODE) int courseCode) {
+      @RequestParam String deptCode, @RequestParam int courseCode) {
     try {
       if (doesCourseExist(deptCode, courseCode)) {
         // determine isCourseFull() when provided a deptCode and courseCode
@@ -155,6 +68,104 @@ public class RouteController {
   }
 
   /**
+   * Helper function to determine if a course exists.
+   *
+   * @param deptCode A {@code String} representing the department the user wishes to retrieve.
+   * @param courseCode A {@code int} representing the course the user wishes to retrieve.
+   * @return A {@code boolean} determining if a course exists or not.
+   */
+  protected boolean doesCourseExist(String deptCode, int courseCode) {
+    return retrieveCourse(deptCode, courseCode).getStatusCode() == HttpStatus.OK;
+  }
+
+  /**
+   * Helper function to retrieve a department's mapping.
+   *
+   * @return A hashmap containing all departments and their designated properties.
+   */
+  protected Map<String, Department> retrieveDeptMapping() {
+    return IndividualProjectApplication.myFileDatabase.getDepartmentMapping();
+  }
+
+  /**
+   * Handles exceptions that occur during the execution of requests. Logs the exception details to
+   * the console and returns a generic error response 200 status. This method is used to provide a
+   * generic error response for exceptions encountered in IndividualProject.
+   *
+   * @param e The exception that was thrown and needs to be handled.
+   * @return A {@link ResponseEntity} containing a generic error message HTTP 200 status.
+   */
+  private ResponseEntity<?> handleException(Exception e) {
+    System.out.println(e.toString());
+    return new ResponseEntity<>("An Error has occurred", HttpStatus.OK);
+  }
+
+  /**
+   * Displays the details of the requested course to the user or displays the proper error message
+   * in response to the request.
+   *
+   * @param deptCode A {@code String} representing the department the user wishes to find the course
+   *     in.
+   * @param courseCode A {@code int} representing the course the user wishes to retrieve.
+   * @return A {@code ResponseEntity} object containing either the details of the course and an HTTP
+   *     200 response or, an appropriate message indicating the proper response.
+   */
+  @GetMapping(value = "/retrieveCourse", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<?> retrieveCourse(
+      @RequestParam String deptCode, @RequestParam int courseCode) {
+    try {
+      if (doesDepartmentExist(deptCode)) {
+        Map<String, Course> coursesMapping =
+            retrieveDeptMapping().get(deptCode).getCourseSelection();
+
+        if (!coursesMapping.containsKey(Integer.toString(courseCode))) {
+          return new ResponseEntity<>(COURSE_NOT_FOUND, HttpStatus.NOT_FOUND);
+        } else {
+          return new ResponseEntity<>(
+              coursesMapping.get(Integer.toString(courseCode)).toString(), HttpStatus.OK);
+        }
+      } else {
+        return new ResponseEntity<>(DEPARTMENT_NOT_FOUND, HttpStatus.NOT_FOUND);
+      }
+    } catch (Exception e) {
+      return handleException(e);
+    }
+  }
+
+  /**
+   * Helper function to determine if a department exists.
+   *
+   * @param deptCode A {@code String} representing the department the user wishes to retrieve.
+   * @return A {@code boolean} determining if department exists or not.
+   */
+  protected boolean doesDepartmentExist(String deptCode) {
+    return retrieveDepartment(deptCode).getStatusCode() == HttpStatus.OK;
+  }
+
+  /**
+   * Returns the details of the specified department.
+   *
+   * @param deptCode A {@code String} representing the department the user wishes to retrieve.
+   * @return A {@code ResponseEntity} object containing either the details of the Department and an
+   *     HTTP 200 response or, an appropriate message indicating the proper response.
+   */
+  @GetMapping(value = "/retrieveDept", produces = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<?> retrieveDepartment(@RequestParam String deptCode) {
+    try {
+      if (!retrieveDeptMapping().containsKey(deptCode.toUpperCase(Locale.ENGLISH))) {
+        return new ResponseEntity<>(DEPARTMENT_NOT_FOUND, HttpStatus.NOT_FOUND);
+      } else {
+        return new ResponseEntity<>(
+            retrieveDeptMapping().get(deptCode.toUpperCase(Locale.ENGLISH)).toString(),
+            HttpStatus.OK);
+      }
+
+    } catch (Exception e) {
+      return handleException(e);
+    }
+  }
+
+  /**
    * Displays the number of majors in the specified department.
    *
    * @param deptCode A {@code String} representing the department the user wishes to find number of
@@ -164,7 +175,7 @@ public class RouteController {
    *     response.
    */
   @GetMapping(value = "/getMajorCountFromDept", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<?> getMajorCtFromDept(@RequestParam(value = DEPT_CODE) String deptCode) {
+  public ResponseEntity<?> getMajorCtFromDept(@RequestParam String deptCode) {
     try {
       if (doesDepartmentExist(deptCode)) {
         int numberOfMajors = retrieveDeptMapping().get(deptCode).getNumberOfMajors();
@@ -187,7 +198,7 @@ public class RouteController {
    *     response.
    */
   @GetMapping(value = "/idDeptChair", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<?> identifyDeptChair(@RequestParam(value = DEPT_CODE) String deptCode) {
+  public ResponseEntity<?> identifyDeptChair(@RequestParam String deptCode) {
     try {
       if (doesDepartmentExist(deptCode)) {
         String departmentChair = retrieveDeptMapping().get(deptCode).getDepartmentChair();
@@ -211,8 +222,7 @@ public class RouteController {
    */
   @GetMapping(value = "/findCourseLocation", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<?> findCourseLocation(
-      @RequestParam(value = DEPT_CODE) String deptCode,
-      @RequestParam(value = COURSE_CODE) int courseCode) {
+      @RequestParam String deptCode, @RequestParam int courseCode) {
     try {
       if (doesCourseExist(deptCode, courseCode)) {
         // retrieves the courseLocation via a specified deptCode and courseCode
@@ -245,8 +255,7 @@ public class RouteController {
    */
   @GetMapping(value = "/findCourseInstructor", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<?> findCourseInstructor(
-      @RequestParam(value = DEPT_CODE) String deptCode,
-      @RequestParam(value = COURSE_CODE) int courseCode) {
+      @RequestParam String deptCode, @RequestParam int courseCode) {
     try {
       if (doesCourseExist(deptCode, courseCode)) {
         // retrieve instructorName via a specified deptCode and courseCode
@@ -279,8 +288,7 @@ public class RouteController {
    */
   @GetMapping(value = "/findCourseTime", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<?> findCourseTime(
-      @RequestParam(value = DEPT_CODE) String deptCode,
-      @RequestParam(value = COURSE_CODE) int courseCode) {
+      @RequestParam String deptCode, @RequestParam int courseCode) {
     try {
       if (doesCourseExist(deptCode, courseCode)) {
         // retrieve courseTimeSlot via a specified deptCode and courseCode
@@ -307,7 +315,7 @@ public class RouteController {
    *     message or the proper status code in tune with what has happened.
    */
   @PatchMapping(value = "/addMajorToDept", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<?> addMajorToDept(@RequestParam(value = DEPT_CODE) String deptCode) {
+  public ResponseEntity<?> addMajorToDept(@RequestParam String deptCode) {
     try {
       if (doesDepartmentExist(deptCode)) {
         // add person to specified deptCode major
@@ -328,7 +336,7 @@ public class RouteController {
    *     message or the proper status code in tune with what has happened.
    */
   @PatchMapping(value = "/removeMajorFromDept", produces = MediaType.APPLICATION_JSON_VALUE)
-  public ResponseEntity<?> removeMajorFromDept(@RequestParam(value = DEPT_CODE) String deptCode) {
+  public ResponseEntity<?> removeMajorFromDept(@RequestParam String deptCode) {
     try {
       if (doesDepartmentExist(deptCode)) {
         // drop person to specified deptCode major
@@ -351,8 +359,7 @@ public class RouteController {
    */
   @PatchMapping(value = "/dropStudentFromCourse", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<?> dropStudent(
-      @RequestParam(value = DEPT_CODE) String deptCode,
-      @RequestParam(value = COURSE_CODE) int courseCode) {
+      @RequestParam String deptCode, @RequestParam int courseCode) {
     try {
       if (doesCourseExist(deptCode, courseCode)) {
         boolean isStudentDropped =
@@ -390,9 +397,7 @@ public class RouteController {
    */
   @PatchMapping(value = "/setEnrollmentCount", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<?> setEnrollmentCount(
-      @RequestParam(value = DEPT_CODE) String deptCode,
-      @RequestParam(value = COURSE_CODE) int courseCode,
-      @RequestParam(value = "count") int count) {
+      @RequestParam String deptCode, @RequestParam int courseCode, @RequestParam int count) {
     try {
       if (doesCourseExist(deptCode, courseCode)) {
         // setEnrolledStudentCount via specified deptCode and courseCode
@@ -424,9 +429,7 @@ public class RouteController {
    */
   @PatchMapping(value = "/changeCourseTime", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<?> changeCourseTime(
-      @RequestParam(value = DEPT_CODE) String deptCode,
-      @RequestParam(value = COURSE_CODE) int courseCode,
-      @RequestParam(value = "time") String time) {
+      @RequestParam String deptCode, @RequestParam int courseCode, @RequestParam String time) {
     try {
       if (doesCourseExist(deptCode, courseCode)) {
         // reassignTime() based on designated courseCode, deptCode, and time
@@ -458,9 +461,7 @@ public class RouteController {
    */
   @PatchMapping(value = "/changeCourseTeacher", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<?> changeCourseTeacher(
-      @RequestParam(value = DEPT_CODE) String deptCode,
-      @RequestParam(value = COURSE_CODE) int courseCode,
-      @RequestParam(value = "teacher") String teacher) {
+      @RequestParam String deptCode, @RequestParam int courseCode, @RequestParam String teacher) {
     try {
       if (doesCourseExist(deptCode, courseCode)) {
         // reassignInstructor based on specified deptCode, courseCode, and new instructor
@@ -494,9 +495,7 @@ public class RouteController {
    */
   @PatchMapping(value = "/changeCourseLocation", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<?> changeCourseLocation(
-      @RequestParam(value = DEPT_CODE) String deptCode,
-      @RequestParam(value = COURSE_CODE) int courseCode,
-      @RequestParam(value = "location") String location) {
+      @RequestParam String deptCode, @RequestParam int courseCode, @RequestParam String location) {
     try {
       if (doesCourseExist(deptCode, courseCode)) {
         // reassignLocation based on deptCode, courseCode, and new location
@@ -512,18 +511,5 @@ public class RouteController {
     } catch (Exception e) {
       return handleException(e);
     }
-  }
-
-  /**
-   * Handles exceptions that occur during the execution of requests. Logs the exception details to
-   * the console and returns a generic error response 200 status. This method is used to provide a
-   * generic error response for exceptions encountered in IndividualProject.
-   *
-   * @param e The exception that was thrown and needs to be handled.
-   * @return A {@link ResponseEntity} containing a generic error message HTTP 200 status.
-   */
-  private ResponseEntity<?> handleException(Exception e) {
-    System.out.println(e.toString());
-    return new ResponseEntity<>("An Error has occurred", HttpStatus.OK);
   }
 }

--- a/IndividualProject/src/test/java/dev/coms4156/project/individualproject/DepartmentTests.java
+++ b/IndividualProject/src/test/java/dev/coms4156/project/individualproject/DepartmentTests.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +26,7 @@ public class DepartmentTests {
   private Course course2;
 
   /** The map of course IDs to Course instances for testing. */
-  private HashMap<String, Course> courses;
+  private Map<String, Course> courses;
 
   /** An empty Department instance used for testing. */
   private Department emptyDepartment;

--- a/IndividualProject/src/test/java/dev/coms4156/project/individualproject/InitializeDatabase.java
+++ b/IndividualProject/src/test/java/dev/coms4156/project/individualproject/InitializeDatabase.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 
 /**
@@ -12,7 +13,7 @@ import org.junit.jupiter.api.BeforeEach;
  */
 public abstract class InitializeDatabase {
   protected static final String FILE_PATH = "src/test/resources/testData.txt";
-  protected HashMap<String, Department> testDepartmentMapping;
+  protected Map<String, Department> testDepartmentMapping;
   protected MyFileDatabase db;
 
   /**
@@ -30,7 +31,7 @@ public abstract class InitializeDatabase {
     // CS courses
     Course csCourse1 = new Course("Adam Cannon", "417 IAB", "11:40-12:55", 30);
     Course csCourse2 = new Course("Tony Dear", "402 CHANDLER", "1:10-3:40", 125);
-    HashMap<String, Course> csCourses = new HashMap<>();
+    Map<String, Course> csCourses = new HashMap<>();
     csCourses.put("1004", csCourse1);
     csCourses.put("3251", csCourse2);
     Department csDepartment = new Department("COMS", csCourses, "Luca Carloni", 2700);
@@ -38,7 +39,7 @@ public abstract class InitializeDatabase {
     // ECON courses
     Course econCourse1 = new Course("Waseem Noor", "309 HAV", "2:40-3:55", 210);
     Course econCourse2 = new Course("Tamrat Gashaw", "428 PUP", "10:10-11:25", 125);
-    HashMap<String, Course> econCourses = new HashMap<>();
+    Map<String, Course> econCourses = new HashMap<>();
     econCourses.put("1105", econCourse1);
     econCourses.put("2257", econCourse2);
     Department econDepartment = new Department("ECON", econCourses, "Michael Woodford", 2345);

--- a/IndividualProject/src/test/java/dev/coms4156/project/individualproject/MyFileDatabaseTests.java
+++ b/IndividualProject/src/test/java/dev/coms4156/project/individualproject/MyFileDatabaseTests.java
@@ -87,24 +87,6 @@ public class MyFileDatabaseTests extends InitializeDatabase {
     assertTrue(Files.exists(filePath), "Expected file at " + filePath + " to exist.");
   }
 
-  //  /**
-  //   * Tests if the deSerializeObjectFromFile() method correctly deserializes the department
-  // mapping
-  //   * from the file.
-  //   */
-  //  @Test
-  //  public void deSerializeFromFileValidation() {
-  //    db.setMapping(testDepartmentMapping);
-  //    db.saveContentsToFile();
-  //    HashMap<String, Department> deSerializedDepartmentMapping = db.deSerializeObjectFromFile();
-  //
-  //    assertEquals(
-  //        testDepartmentMapping.toString(),
-  //        deSerializedDepartmentMapping.toString(),
-  //        "Expected testDepartmentMapping and deSerializedDepartmentMapping to have the same "
-  //            + "string output.");
-  //  }
-
   /**
    * Tests if the toString() method of MyFileDatabase produces the expected formatted string output.
    */

--- a/README.md
+++ b/README.md
@@ -7,4 +7,5 @@ see all audit checks relating to Checkstyle violations, all tests that have run,
 status of the build. `PMD` is added as a dependency within the `pom.xml` file. This assignment was
 completed on Mac OS using IntelliJ. Additional dependencies that were added are `mockito-core`,
 `mockito-junit-jupiter`, `junit-jupiter-engine`, and, for reporting,
-`maven-project-info-reports-plugin`. See the `pom.xml` for specific versions.
+`maven-project-info-reports-plugin`. See the `pom.xml` for specific versions. All information
+relating to bug/style fixes can be found in `bugs.md`.


### PR DESCRIPTION
## Description (IMPORTANT)

Added some additional information to `bugs.md`. Here is the text:

Originally, I used the PMD rulesets:
```
<ruleset>category/java/errorprone.xml</ruleset>
<ruleset>rulesets/java/maven-pmd-plugin-default.xml</ruleset>
```

These were defined as satisfactory rulesets according to this EdStem post ([#140](https://edstem/. org/us/courses/58089/discussion/5269277?comment=12209100)). However, after adding a ruleset, `rulesets/java/quickstart.xml`, I received more violations. These were cleaned up after the fact. I'm hoping that I will not be marked off points because the TA specified that the `errorprone.xml` and `maven-pmd-plugin-default.xml` would be sufficient. Either way, here are the violations corresponding to `rulesets/java/quickstart.xml` that have been resolved.